### PR TITLE
Introduce configuration option for zone and ttl.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ secret-base64 = "dG9wc2VjcmV0Cg=="
 key = "mykey"
 # DNS name to update
 name = "dyndns.example.net"
+zone = "example.net"
+# # Optionally define a time to live (ttl) for the record to set. The default ttl is 0
+# ttl = 7200
 # Network interface to watch for an IP address
 interface = "ppp0"
 # # Optionally select the proper IP address by subnet. This is the
@@ -61,6 +64,9 @@ interface = "ppp0"
 key = "mykey"
 # DNS name to update
 name = "dyndns.example.net"
+zone = "example.net"
+# # Optionally define a time to live (ttl) for the record to set. The default ttl is 0
+# ttl = 7200
 # Network interface to watch for an IP address
 interface = "ppp0"
 # # Optionally select the proper IP address by subnet. This is the

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,7 +60,7 @@ pub struct UpdateTask {
     pub key: String,
     pub name: String,
     pub interface: String,
-    pub zone: String,
+    pub zone: Option<String>,
     pub ttl: Option<u32>,
     pub scope: Option<String>,
     pub neighbors: Option<HashMap<String, Ipv6Addr>>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,6 +60,8 @@ pub struct UpdateTask {
     pub key: String,
     pub name: String,
     pub interface: String,
+    pub zone: String,
+    pub ttl: Option<u32>,
     pub scope: Option<String>,
     pub neighbors: Option<HashMap<String, Ipv6Addr>>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,7 +56,7 @@ impl TsigKey {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct Interface {
+pub struct UpdateTask {
     pub key: String,
     pub name: String,
     pub interface: String,
@@ -67,8 +67,8 @@ pub struct Interface {
 #[derive(Debug, Deserialize)]
 pub struct Config {
     pub keys: HashMap<String, TsigKey>,
-    pub a: Option<Vec<Interface>>,
-    pub aaaa: Option<Vec<Interface>>,
+    pub a: Option<Vec<UpdateTask>>,
+    pub aaaa: Option<Vec<UpdateTask>>,
 }
 /// # Errors
 ///

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -81,12 +81,13 @@ impl Server {
     /// - deletion of resource record set failed.
     /// - appending the new record failed.
     ///
-    pub async fn update(&mut self, hostname: &str, addr: IpAddr) -> Result<(), String> {
+
+    pub async fn update(&mut self, name: &str, addr: IpAddr) -> Result<(), String> {
         let rdata = match addr {
             IpAddr::V4(addr) => RData::A(addr),
             IpAddr::V6(addr) => RData::AAAA(addr),
         };
-        let name = Name::from_str(hostname)?;
+        let name = Name::from_str(name)?;
         let origin = name.base_name();
         let rec = Record::from_rdata(name, 0, rdata);
         let query = self.client.delete_rrset(rec.clone(), origin.clone());
@@ -96,7 +97,7 @@ impl Server {
             return Err(format!("Response code: {}", response.response_code()));
         }
         let query = self.client.append(rec, origin, false);
-        info!("DNS update: {} {}", hostname, addr);
+        info!("DNS update: {} {}", name, addr);
         let response = query.await.map_err(|e| format!("{e}"))?;
 
         if response.response_code() != ResponseCode::NoError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,13 +58,19 @@ impl RecordState {
             _ => panic!("scope {} doesn't match address family {:?}", scope, af),
         }
 
-        let zone = match update_task.zone {
-            Some(zone) => Some(Rc::new(zone)),
-            None => {
-                warn!("Your configuration misses the `zone` parameter. This field will be mandatory in a future release.");
-                None
-            }
+        let zone = if let Some(zone) = update_task.zone {
+            Some(Rc::new(zone))
+        } else {
+            warn!("Your configuration misses the `zone` parameter. This field will be mandatory in a future release.");
+            None
         };
+        //let zone = match update_task.zone {
+        //    Some(zone) => Some(Rc::new(zone)),
+        //    None => {
+        //        warn!("Your configuration misses the `zone` parameter. This field will be mandatory in a future release.");
+        //        None
+        //    }
+        //};
 
         RecordState {
             server,
@@ -73,7 +79,7 @@ impl RecordState {
 
             addr: None,
             ttl: update_task.ttl.unwrap_or(0),
-            zone: zone,
+            zone,
             scope,
             dirty: false,
             update_tried: None,
@@ -189,10 +195,7 @@ impl RecordState {
             }
         }
 
-        let zone = match &self.zone {
-            Some(zone) => Some(zone.as_str()),
-            None => None,
-        };
+        let zone = self.zone.as_ref().map(|zone| zone.as_str());
 
         server.update(name, *addr, zone, self.ttl).await
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,9 @@ use log::error;
 
 #[tokio::main]
 async fn main() -> Result<(), String> {
-    env_logger::init();
+    let env = env_logger::Env::default().filter_or("RUST_LOG", "info");
+
+    env_logger::init_from_env(env);
 
     let args = std::env::args().collect::<Vec<_>>();
     if args.len() != 2 {


### PR DESCRIPTION
Hello!

This pull request addresses #6. Since other clients like `knsupdate` allow explicitly setting the zone, I took the same approach by introducing new configuration variables.

This pull request also introduces setting the TTL.

In general, this is a breaking change, since new configurations are now supposed to set `zone`.