### PR TITLE
Make name optional to allow aaaa records to only update neighbors

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -58,7 +58,7 @@ impl TsigKey {
 #[derive(Debug, Deserialize)]
 pub struct UpdateTask {
     pub key: String,
-    pub name: String,
+    pub name: Option<String>,
     pub interface: String,
     pub zone: Option<String>,
     pub ttl: Option<u32>,


### PR DESCRIPTION
Tested this on my deployment and the log indicated success.