### PR TITLE
Fix overlay without aliases enabled, move package one layer higher

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,7 @@
           packages = [ pkgs.cargo-edit ];
         };
       }) // {
-        overlay = final: prev: { ifdyndnsd = self.packages.${prev.system}; };
+        overlay = final: prev: { inherit (self.packages.${prev.stdenv.system}) ifdyndnsd; };
 
         nixosModule = import ./nixos-module.nix { inherit self; };
       };


### PR DESCRIPTION
so that the following codes works

nixpkgs.overlays = [ inputs.ifdyndnsd.overlay ];